### PR TITLE
Redmine plugin の gem 化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+*.bundle
+*.so
+*.o
+*.a
+mkmf.log

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in redmine_gantt_view_overwrite.gemspec
+gemspec(:path => File.dirname(__FILE__))

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Getting the plugin
 
 A copy of the plugin can be downloaded from [GitHub](https://github.com/occ-corp/redmine_gantt_view_overwrite.git)
 
+USAGE
+--------------------------------------------------------------------------------
+
+1. Add the gem to `$REDMINE_DIR/Gemfile.local`: `gem 'redmine_gantt_view_overwrite'`
+2. `bundle`
+3. Restart Redmine
+
 
 LICENSE
 --------------------------------------------------------------------------------

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require "bundler/gem_tasks"
+

--- a/init.rb
+++ b/init.rb
@@ -4,7 +4,8 @@ Redmine::Plugin.register :redmine_gantt_view_overwrite do
   name 'Redmine Gantt View Overwrite plugin'
   author 'Tomohiro TAIRA'
   description 'This is a gantt view overwrite plugin for Redmine'
-  version '0.0.4'
+  version RedmineGanttViewOverwrite::VERSION
   url 'http://github.com/occ-corp/redmine_gantt_view_overwrite'
   author_url 'https://github.com/Tomohiro'
+  directory File.expand_path("../", __FILE__)
 end

--- a/lib/redmine_gantt_view_overwrite.rb
+++ b/lib/redmine_gantt_view_overwrite.rb
@@ -1,0 +1,9 @@
+require "redmine_gantt_view_overwrite/version"
+
+module RedmineGanttViewOverwrite
+  class Plugin < ::Rails::Engine
+    config.after_initialize do
+      require File.expand_path("../../init", __FILE__)
+    end
+  end
+end

--- a/lib/redmine_gantt_view_overwrite/version.rb
+++ b/lib/redmine_gantt_view_overwrite/version.rb
@@ -1,0 +1,3 @@
+module RedmineGanttViewOverwrite
+  VERSION = "0.0.4"
+end

--- a/redmine_gantt_view_overwrite.gemspec
+++ b/redmine_gantt_view_overwrite.gemspec
@@ -1,0 +1,22 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'redmine_gantt_view_overwrite/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "redmine_gantt_view_overwrite"
+  spec.version       = RedmineGanttViewOverwrite::VERSION
+  spec.authors       = ["Tomohiro TAIRA"]
+  spec.email         = ["tomohiro@occ.co.jp"]
+  spec.summary       = %q{This is a gantt view overwrite plugin for Redmine}
+  spec.description   = %q{This is a gantt view overwrite plugin for Redmine}
+  spec.homepage      = "http://github.com/occ-corp/redmine_gantt_view_overwrite"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
+end


### PR DESCRIPTION
@Tomohiro レビューお願いします
### やりたいこと

plugin を gem 化して Gemfile で管理するようにしたい
### やったこと

gem 化するためのファイル追加
### やってないこと
- gem relase

リリースしなくとも Gemfile で `github:` オプション指定すれば使えなくはないかと思います
### 使い方

Redmine が `$REDMINE_DIR/Gemfile.local` を評価するということがわかったので、
その方法を README に書きました。

``` bash
$ echo "gem 'redmine_gantt_view_overwrite'" > Gemfile.local
$ bundle
```
### 主にレビューお願いしたい箇所

gemspec 適当に項目埋めた感じなのでレビューお願いします
